### PR TITLE
Let update stack calls use previous param value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # aws-ruby
+
+
+### client_params
+
+The AWS CLI (and SDK) expect stack parameters to be passed in a certain format.  This gem provides a utility method
+called `client_params` that just asks for a simple ruby hash that it then converts to the format expected by the SDK.
+
+```ruby
+client_params(
+  network_stack_name: network_stack_name,
+  env_name: env_name,
+  some_other_param: that_params_value,
+  a_param_we_are_not_changing: :use_previous_value
+)
+```
+
+Note that when this helper is used in a call to update a stack, you can use the special `:use_previous_value` value
+and AWS will reuse the parameter value used in the last create or update stack call.

--- a/lib/openstax/aws/deployment_base.rb
+++ b/lib/openstax/aws/deployment_base.rb
@@ -108,8 +108,13 @@ module OpenStax::Aws
       params.map do |key, value|
         {
           parameter_key: key.to_s.split('_').collect(&:capitalize).join,
-          parameter_value: value
-        }
+        }.tap do |hash|
+          if value == :use_previous_value
+            hash[:use_previous_value] = true
+          else
+            hash[:parameter_value] = value
+          end
+        end
       end
     end
 


### PR DESCRIPTION
The CLI lets you not provide parameter values in a stack update call and instead just reuse the value provided in the prior call.  This PR updates the gem to make that functionality available.