### PR TITLE
Support multiple parameters sets per deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ client_params(
 
 Note that when this helper is used in a call to update a stack, you can use the special `:use_previous_value` value
 and AWS will reuse the parameter value used in the last create or update stack call.
+
+### README Todos
+
+1. Discuss use of multiple parameters objects

--- a/lib/openstax/aws/deployment_base.rb
+++ b/lib/openstax/aws/deployment_base.rb
@@ -239,11 +239,13 @@ module OpenStax::Aws
       end
     end
 
-    def parameters
-      @parameters ||= OpenStax::Aws::Parameters.new(
+    def parameters(id: 'default')
+      id = id.to_s
+      @parameters ||= {}
+      @parameters[id] ||= OpenStax::Aws::Parameters.new(
         region: region,
         env_name: env_name!,
-        parameter_namespace: parameter_namespace
+        parameter_namespace: parameter_namespace(id: id)
       )
     end
 
@@ -268,7 +270,7 @@ module OpenStax::Aws
 
     protected
 
-    def parameter_namespace
+    def parameter_namespace(id: 'default')
       raise "Override this method in your deployment class and provide a namespace " \
             "for data in the AWS Parameter Store.  The parameter key will be this namespace " \
             "prefixed by the environment name and suffixed with the parameter name."


### PR DESCRIPTION
Now instead of just using one `parameters` object per deployment, you can use multiple, e.g. `parameters(id: 'admin_node')` and `parameters(id: 'api_node')`.