### PR TITLE
env_name-less stack names, stack name overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ stack :app do
 end
 ```
 
+Blocks passed to the stack definition methods (like `region` above) are executed in the context of the
+containing deployment object.
+
 When using the DSL, you can define a stack-local `template_directory` to override the deployment-level
 one, e.g.
 

--- a/lib/openstax/aws/deployment_base.rb
+++ b/lib/openstax/aws/deployment_base.rb
@@ -51,13 +51,13 @@ module OpenStax::Aws
 
         define_method("#{id}_stack") do
           instance_variable_get("@#{id}_stack") || begin
-            stack_factory = StackFactory.new(id: id, parameter_context: self)
+            stack_factory = StackFactory.new(id: id, deployment: self)
             stack_factory.instance_eval(&block) if block_given?
 
             # Fill in missing attributes using deployment variables and conventions
 
             if stack_factory.name.blank?
-              stack_factory.name("#{env_name}-#{name}-#{id}")
+              stack_factory.name([env_name,name,id].compact.join("-"))
             end
 
             if stack_factory.region.blank?
@@ -73,7 +73,7 @@ module OpenStax::Aws
             end
 
             if stack_factory.absolute_template_path.blank?
-              stack_factory.autoset_absolute_template_path(defined?(:template_directory) ? template_directory : "")
+              stack_factory.autoset_absolute_template_path(respond_to?(:template_directory) ? template_directory : "")
             end
 
             # Populate parameter defaults that match convention names

--- a/lib/openstax/aws/deployment_base.rb
+++ b/lib/openstax/aws/deployment_base.rb
@@ -44,6 +44,10 @@ module OpenStax::Aws
       end
 
       def stack(id, &block)
+        if id.blank?
+          raise "The first argument to `stack` must be a non-blank ID"
+        end
+
         if !id.to_s.match(/^[a-zA-Z][a-zA-Z0-9_]*$/)
           raise "The first argument to `stack` must consist only of letters, numbers, and underscores, " \
                 "and must start with a letter."

--- a/lib/openstax/aws/stack.rb
+++ b/lib/openstax/aws/stack.rb
@@ -1,15 +1,16 @@
 module OpenStax::Aws
   class Stack
 
-    attr_reader :name, :absolute_template_path, :dry_run,
+    attr_reader :name, :id, :absolute_template_path, :dry_run,
                 :enable_termination_protection, :region, :parameter_defaults,
                 :volatile_parameters_block
 
-    def initialize(name:, region:, enable_termination_protection: false,
+    def initialize(id: nil, name:, region:, enable_termination_protection: false,
                    absolute_template_path: nil,
                    capabilities: nil, parameter_defaults: {},
                    volatile_parameters_block: nil,
                    dry_run: true)
+      @id = id
 
       raise "Stack name must not be blank" if name.blank?
       @name = name

--- a/spec/deployment_base_spec.rb
+++ b/spec/deployment_base_spec.rb
@@ -133,6 +133,15 @@ RSpec.describe OpenStax::Aws::DeploymentBase do
       expect(instance.app_stack.name).to eq "my-spec-override-app"
     end
 
+    it "must be given an id" do
+      expect{
+        deployment_class = Class.new(described_class) do
+          template_directory __dir__, 'support/templates/factory_test'
+          stack nil do
+          end
+        end
+      }.to raise_error(StandardError, /first argument/)
+    end
   end
 
   context "#template_directory" do

--- a/spec/deployment_base_spec.rb
+++ b/spec/deployment_base_spec.rb
@@ -109,6 +109,30 @@ RSpec.describe OpenStax::Aws::DeploymentBase do
       expect(instance.app_stack.enable_termination_protection).to eq true
     end
 
+    it "makes good stack names when env_name not set" do
+      deployment_class = Class.new(described_class) do
+        template_directory __dir__, 'support/templates/factory_test'
+        stack :app
+      end
+
+      instance = deployment_class.new(name: "spec", region: "deployment-region", dry_run: false)
+
+      expect(instance.app_stack.name).to eq "spec-app"
+    end
+
+    it "can have stack name overridden" do
+      deployment_class = Class.new(described_class) do
+        template_directory __dir__, 'support/templates/factory_test'
+        stack :app do
+          name { "my-#{name}-override-app" }
+        end
+      end
+
+      instance = deployment_class.new(name: "spec", region: "deployment-region", dry_run: false)
+
+      expect(instance.app_stack.name).to eq "my-spec-override-app"
+    end
+
   end
 
   context "#template_directory" do

--- a/spec/stack_factory_spec.rb
+++ b/spec/stack_factory_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe OpenStax::Aws::StackFactory do
       count: 2
     )
 
-    stack = described_class.build(id: :bar, parameter_context: context) do
+    stack = described_class.build(id: :bar, deployment: context) do
       name "something"
       capabilities [:iam]
       region "us-east-1"
@@ -25,7 +25,7 @@ RSpec.describe OpenStax::Aws::StackFactory do
   end
 
   it 'manages volatile parameters' do
-    stack = described_class.build(id: :bar, parameter_context: OpenStruct.new) do
+    stack = described_class.build(id: :bar, deployment: OpenStruct.new) do
       name "something"
       capabilities [:iam]
       region 'us-east-1'


### PR DESCRIPTION
* Ensure that deployments without an `env_name` do not generate stack names starting with a hyphen.
* Allow stack names to be manually defined using methods executed in the scope of the deployment