### PR TITLE
drop responsibility for non-locally-used params

### DIFF
--- a/examples/deployment.rb
+++ b/examples/deployment.rb
@@ -3,44 +3,39 @@ require 'byebug'
 module OpenStax::Aws::SomeApp
   class Deployment < OpenStax::Aws::DeploymentBase
 
-    def initialize(env_name:, region:)
-      super(env_name: env_name, region: region, name: "some_name")
+    stack :network
+    stack :redis
+    stack :app do
+      parameter_defaults do
+        web_server_desired_capacity '1'
+        parameter_namespace { parameter_namespace }
+      end
+      volatile_parameters do
+        web_server_desired_capacity { resource("Asg").desired_capacity }
+      end
+    end
+
+    def initialize(env_name:, region:, dry_run: true)
+      super(env_name: env_name, region: region, name: "some_name", dry_run: dry_run)
     end
 
     def create(app_image_id:, sha: nil)
-      create_network_stack
-      create_redis_stack
+      network_stack.create
+      redis_stack.create
+
+      network_stack.wait_for_stack_creation
+      redis_stack.wait_for_stack_creation
+
       create_parameters(deployed_app_sha: sha || image_sha(app_image_id))
-      create_app_stack(app_image_id: app_image_id)
-    end
 
-    def create_network_stack(wait: true)
-      upload_template(absolute_file_path: File.join(File.dirname(__FILE__), "network.yml"))
-
-      client.create_stack(
-        stack_name: network_stack_name,
-        template_url: template_url(file_name: "network.yml")
-      )
-
-      wait_for_stack_creation(stack_name: network_stack_name) if wait
-    end
-
-    def create_redis_stack(wait: true)
-      upload_template(absolute_file_path: File.join(File.dirname(__FILE__), "redis.yml"))
-
-      client.create_stack(
-        stack_name: redis_stack_name,
-        template_url: template_url(file_name: "redis.yml"),
-        parameters: client_params(
-          network_stack_name: network_stack_name
-        )
-      )
-
-      wait_for_stack_creation(stack_name: redis_stack_name) if wait
+      app_stack.create(params: {
+        branch_name_or_sha: sha || "",
+        web_server_image_id: app_image_id,
+      })
     end
 
     def create_parameters(deployed_app_sha:)
-      redis_host = stack_output_value(stack: redis_stack, key: "ElastiCacheAddress")
+      redis_host = redis_stack.output_value(key: "ElastiCacheAddress")
 
       parameters.create(
         specification: OpenStax::Aws::ParametersSpecification.from_git(
@@ -51,98 +46,44 @@ module OpenStax::Aws::SomeApp
           top_key: :production
         ),
         substitutions: {
-          domain: domain,
           env_name: env_name,
           redis_url: "redis://#{redis_host}:6379/0"
         }
       )
     end
 
-    def create_app_stack(app_image_id:)
-      upload_template(absolute_file_path: File.join(File.dirname(__FILE__), "app.yml"))
-
-      client.create_stack(
-        stack_name: app_stack_name,
-        template_url: template_url(file_name: "app.yml"),
-        capabilities: ["CAPABILITY_IAM"],
-        parameters: client_params(
-          network_stack_name: network_stack_name,
-          env_name: env_name,
-          branch_name_or_sha: "",
-          hosted_zone_name: "something.domain.com",
-          domain: domain,
-          web_server_image_id: app_image_id,
-          web_server_desired_capacity: '1',
-          parameter_namespace: parameter_namespace,
-          key_name: "some-aws-keypair-name"
-        )
-      )
-    end
-
     def delete
-      delete_stack(stack_name: app_stack_name)
-      delete_stack(stack_name: redis_stack_name)
+      app_stack.delete
+      redis_stack.delete
 
-      wait_for_stack_deletion(stack_name: app_stack_name)
-      wait_for_stack_deletion(stack_name: redis_stack_name)
+      app_stack.wait_for_stack_deletion
+      redis_stack.wait_for_stack_deletion
 
       parameters.delete
 
-      delete_stack(stack_name: network_stack_name)
+      network_stack.delete
     end
 
     def update_app_image(new_app_image_id:, dry_run: true)
-      apply_change_set(dry_run: dry_run, params: {
-        stack_name: app_stack_name,
-        template_url: template_url(file_name: "app.yml"),
-        capabilities: ["CAPABILITY_IAM"],
-        parameters: client_params(
-          network_stack_name: network_stack_name,
-          env_name: env_name,
-          branch_name_or_sha: "",
-          hosted_zone_name: "something.domain.com",
-          domain: domain,
-          web_server_image_id: new_app_image_id,
-          web_server_desired_capacity: asg.desired_capacity.to_s,
-          parameter_namespace: parameter_namespace,
-          key_name: "some-aws-keypair-name"
-        ),
-        change_set_name: "update-app-image-#{Time.now.utc.strftime("%Y%m%d-%H%M%S")}-#{new_app_image_id}"
+      app_stack.apply_change_set(params: {
+        web_server_image_id: new_app_image_id
       })
     end
 
     protected
 
+    # A good way to handle deployment-wide stack parameter defaults
+    def parameter_default(parameter_name)
+      case parameter_name
+      when "HostedZoneName"
+        "something.domain.com"
+      when "KeyName"
+        "my-key-pair-on-aws"
+      end
+    end
+
     def parameter_namespace
       'some_name'
-    end
-
-    def domain
-      build_domain(site_name: "some_name")
-    end
-
-    def network_stack_name
-      "some_name-#{env_name}-network"
-    end
-
-    def redis_stack_name
-      "some_name-#{env_name}-redis"
-    end
-
-    def app_stack_name
-      "some_name-#{env_name}-app"
-    end
-
-    def asg_name
-      "some_name-#{env_name}-app-web-asg"
-    end
-
-    def asg
-      auto_scaling_group(name: asg_name)
-    end
-
-    def redis_stack
-      @redis_stack ||= Aws::CloudFormation::Stack.new(redis_stack_name, client, region: region)
     end
 
   end

--- a/lib/openstax_aws.rb
+++ b/lib/openstax_aws.rb
@@ -27,14 +27,11 @@ module OpenStax
     end
 
     class Configuration
-      attr_writer :hosted_zone_name
       attr_writer :cfn_template_bucket_name
       attr_writer :cfn_template_bucket_region
-      attr_writer :log_bucket_name
-      attr_writer :logger
-      attr_writer :key_pair_name
-      attr_accessor :stack_waiter_delay
       attr_accessor :cfn_template_bucket_folder
+      attr_writer :logger
+      attr_accessor :stack_waiter_delay
       attr_accessor :infer_stack_capabilities
       attr_accessor :infer_parameter_defaults
       attr_accessor :production_env_name
@@ -45,11 +42,6 @@ module OpenStax
         @infer_stack_capabilities = true
         @infer_parameter_defaults = true
         @production_env_name = "production"
-      end
-
-      def hosted_zone_name
-        raise "hosted_zone_name isn't set!" if @hosted_zone_name.blank?
-        @hosted_zone_name
       end
 
       def cfn_template_bucket_name
@@ -68,16 +60,6 @@ module OpenStax
         # @cfn_template_bucket_region ||= ::Aws::S3::Client.new(region: "us-east-1") # could be any region
         #   .get_bucket_location(bucket: cfn_template_bucket_name)
         #   .location_constraint
-      end
-
-      def log_bucket_name
-        raise "log_bucket_name isn't set!" if @log_bucket_name.blank?
-        @log_bucket_name
-      end
-
-      def key_pair_name
-        raise "key_pair_name isn't set!" if @key_pair_name.blank?
-        @key_pair_name
       end
 
       def logger

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,3 @@ RSpec.configure do |config|
 end
 
 Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }
-
-OpenStax::Aws.configure do |config|
-  config.key_pair_name = "dummy-kp"
-end

--- a/spec/stack_spec.rb
+++ b/spec/stack_spec.rb
@@ -9,11 +9,8 @@ RSpec.describe OpenStax::Aws::Stack, vcr: VCR_OPTS do
     @logger = spy("logger")
 
     OpenStax::Aws.configure do |config|
-      config.hosted_zone_name = "sandbox.openstax.org"
       config.cfn_template_bucket_name = "openstax-sandbox-cfn-templates"
       config.cfn_template_bucket_region = "us-west-2"
-      config.log_bucket_name = "openstax-sandbox-logs"
-      config.key_pair_name = "openstax-sandbox-kp"
       config.stack_waiter_delay = vcr_recording? ? 5 : 0
       config.logger = @logger
     end

--- a/spec/support/templates/parameter_defaults/app.yml
+++ b/spec/support/templates/parameter_defaults/app.yml
@@ -1,0 +1,30 @@
+Description: >
+  Parameter defaults app
+
+Parameters:
+
+  BucketName:
+    Type: String
+
+  TagValue:
+    Type: String
+
+  EnvName:
+    Type: String
+
+Resources:
+
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref 'BucketName'
+      Tags:
+        - Key: Tag1
+          Value: !Ref 'TagValue'
+
+Outputs:
+
+  BucketArn:
+    Value: !GetAtt 'S3Bucket.Arn'
+    Export:
+      Name: !Sub '${AWS::StackName}-BucketArn'


### PR DESCRIPTION
aws-ruby had been managing some variables as a convenience to the users of this library (e.g. key pair name, log bucket names, hosted zone names, etc).  This PR drops the holding of these variables because they are not applicable to all users, and users can manage them themselves.  Also added methods for defining deployment-wide stack parameter defaults and provides a way for a deployment to override the built-in parameter defaults provided by this gem.  See the README.