### PR TITLE
better spec executables list; exclude templates

### DIFF
--- a/openstax_aws.gemspec
+++ b/openstax_aws.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = "bin"
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{^bin/}).grep_v(%r{/templates/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk-autoscaling", "~> 1"


### PR DESCRIPTION
There's a template in the bin directory used by one of the executables, this PR excludes it from the gem spec's executables list to prevent errors like this when apps bundle:

```
Using openstax_aws 0.1.0 from https://github.com/openstax/aws-ruby.git (at c139dbf@c139dbf)
`/home/ubuntu/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/aws-ruby-c139dbf3c203/bin/aws_ruby_development.yml` does not exist, maybe `gem pristine openstax_aws` will fix it?
```