### PR TITLE
Limit increase of desired capacity to max_size

### DIFF
--- a/lib/openstax/aws/auto_scaling_group.rb
+++ b/lib/openstax/aws/auto_scaling_group.rb
@@ -12,9 +12,12 @@ module OpenStax::Aws
     end
 
     def increase_desired_capacity(by:)
+      # take the smaller of max size or desired+by (or this call raises an exception)
+      increase_to = [raw_asg.max_size, raw_asg.desired_capacity + by].min
+
       raw_asg.set_desired_capacity(
         {
-          desired_capacity: raw_asg.desired_capacity() + by
+          desired_capacity: increase_to
         })
     end
 

--- a/spec/auto_scaling_group_spec.rb
+++ b/spec/auto_scaling_group_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe OpenStax::Aws::AutoScalingGroup do
-  let(:double_asg) { double(desired_capacity: 2) }
+  let(:max_size) { 10 }
+  let(:double_asg) { double(desired_capacity: 2, max_size: max_size) }
 
   subject(:asg) { described_class.new(name:'foo', region: 'bar') }
 
@@ -12,5 +13,14 @@ RSpec.describe OpenStax::Aws::AutoScalingGroup do
   it 'creates the auto scaling group' do
     expect(double_asg).to receive(:set_desired_capacity).with({desired_capacity: 6})
     asg.increase_desired_capacity(by: 4)
+  end
+
+  context "when target is greater than max" do
+    let(:expected_param) { { desired_capacity: max_size} }
+
+    it 'creates the auto scaling group' do
+      expect(double_asg).to receive(:set_desired_capacity).with(expected_param)
+      asg.increase_desired_capacity(by: 50)
+    end
   end
 end


### PR DESCRIPTION
If you call aws set_desired_capacity with a value greater than max_size it raises an aws exception. This limits the increase to the max so that it will run at max_size even if the request is higher.

Picture of the aws exception caused by this issue
![image](https://user-images.githubusercontent.com/352161/63040259-f27b5500-be79-11e9-8db4-9b14da1b50ce.png)
