### PR TITLE
Handled embedded Ruby (ERB) in secrets specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,8 @@ stack :api do
       path { "config/secrets.yml.example" }
       sha { parameters.sha }
       format { :yml }
-      top_key { :production }
+      top_key { :production }    # optional
+      preparser { :erb }         # optional, use if your YAML file has embedded Ruby
     end
     substitutions do
       domain { domain }

--- a/lib/openstax/aws/secrets_factory.rb
+++ b/lib/openstax/aws/secrets_factory.rb
@@ -40,13 +40,15 @@ module OpenStax::Aws
             sha: attributes[:sha],
             path: attributes[:path],
             format: attributes[:format].to_sym,
-            top_key: attributes[:top_key].to_sym
+            top_key: attributes[:top_key].to_sym,
+            preparser: attributes[:preparser]
           )
         elsif attributes.has_key?(:content)
           OpenStax::Aws::SecretsSpecification.from_content(
             content: attributes[:content],
             format: attributes[:format],
-            top_key: attributes[:top_key]
+            top_key: attributes[:top_key],
+            preparser: attributes[:preparser]
           )
         else
           raise "Cannot build a secrets specification"

--- a/lib/openstax/aws/secrets_specification.rb
+++ b/lib/openstax/aws/secrets_specification.rb
@@ -1,36 +1,43 @@
 require 'yaml'
+require 'erb'
 
 module OpenStax::Aws
   class SecretsSpecification
 
     attr_reader :data
 
-    def self.from_file_name(file_name:, format:, top_key: nil)
+    def self.from_file_name(file_name:, format:, top_key: nil, preparser: nil)
       file = File.open(file_name, "r")
       content = file.read
       file.close
-      new(content: content, format: format, top_key: top_key)
+      new(content: content, format: format, top_key: top_key, preparser: preparser)
     end
 
-    def self.from_git(org_slash_repo:, sha:, path:, format:, top_key: nil)
+    def self.from_git(org_slash_repo:, sha:, path:, format:, top_key: nil, preparser: nil)
       content = OpenStax::Aws::GitHelper.file_content_at_sha(
                   org_slash_repo: org_slash_repo,
                   sha: sha,
                   path: path
                 )
-      new(content: content, format: format, top_key: top_key)
+      new(content: content, format: format, top_key: top_key, preparser: preparser)
     end
 
-    def self.from_content(content:, format: nil, top_key: nil)
-      new(content: content, format: format, top_key: top_key)
+    def self.from_content(content:, format: nil, top_key: nil, preparser: nil)
+      new(content: content, format: format, top_key: top_key, preparser: preparser)
     end
 
-    def initialize(content:, format: nil, top_key: nil)
+    def initialize(content:, format: nil, top_key: nil, preparser: nil)
       case content
       when Hash
         @data = content.dup
       when String
         raise "#{format} is not yet handled" if :yml != format
+
+        case (preparser || 'none').to_sym
+        when :erb
+          content = parse_erb(content)
+        end
+
         @data = YAML.load(content)
       else
         raise "Unknown secrets specification inline content type: #{content.class}"
@@ -51,6 +58,10 @@ module OpenStax::Aws
       return g.update({ f=>h }) unless h.is_a? Hash
       h.each { |k,r| flat_hash(r,f+[k],g) }
       g
+    end
+
+    def parse_erb(string)
+      (ERB.new string).result(binding)
     end
 
   end

--- a/spec/secrets_factory_spec.rb
+++ b/spec/secrets_factory_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe OpenStax::Aws::SecretsFactory do
+
+  let (:instance) {
+    described_class.new(region: "us-east-1", context: "foo", namespace: nil, for_create_or_update: nil)
+  }
+
+  it 'accepts a preparser argument' do
+    instance.specification do
+      content { "foo: <%= 42 %>" }
+      format { :yml }
+      preparser { :erb }
+    end
+
+    expect(instance.specification_instances[0].data).to eq ({"foo" => 42})
+  end
+
+end

--- a/spec/secrets_specification_spec.rb
+++ b/spec/secrets_specification_spec.rb
@@ -9,4 +9,18 @@ RSpec.describe OpenStax::Aws::SecretsSpecification do
     expect(spec.data).not_to eq({"foo"=>"{{ bar }}"})
   end
 
+  it "handles YAML with embedded Ruby code" do
+    content = <<~CONTENT
+      foo:
+        <% if true %>
+        bar: 42
+        <% else %>
+        bar: 21
+        <% end %>
+      production:
+        bar: 84
+    CONTENT
+    spec = described_class.from_content(content: content, format: :yml, preparser: :erb)
+  end
+
 end


### PR DESCRIPTION
Some of our secrets specification files (e.g. https://github.com/openstax/accounts/blob/master/config/secrets.yml.example) have embedded Ruby.  This PR adds a `preparser { :erb }` option to the secrets `specification` block to allow the specification to handle that ERB.