### PR TITLE
handle array secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,8 @@ Value: 019af8dc
 
 Instead of `random(hex, number_of_hex_characters])` you can use `uuid` to get a UUID or `base64` to get a URL-safe base 64 string.  Note that generated secrets are only updated during a stack update if their specification changes (that way things like randomly generated secret keys don't change on each deployment unless how the value is computed changes).
 
+Also note that if an array of secrets in the specification contains a generated secret, the overall `StringList` secret written to the parameter store is not marked as generated and so _would_ be changed in an update; the lesson of which is that this library only partially handles generative secrets in arrays.
+
 ##### Referential secrets
 
 Referential secrets let you say that a secret should take the value of another parameter in the parameter store.  They


### PR DESCRIPTION
Handle the case where a secrets specification includes an array, e.g. 

```yaml
foo: 
  - bar1
  - bar2
```