### PR TITLE
Adding short sleep

### DIFF
--- a/lib/openstax/aws/secrets.rb
+++ b/lib/openstax/aws/secrets.rb
@@ -43,6 +43,7 @@ module OpenStax::Aws
       if !dry_run
         built_secrets.each do |built_secret|
           client.put_parameter(built_secret.merge(overwrite: true))
+          sleep(0.1)
         end
       end
     end


### PR DESCRIPTION
With the additional parameters that need to be created with Accounts, I have hit a throttling error multiple times now: 
```
Traceback (most recent call last):
	16: from ./create_env:35:in `<main>'
	15: from ./create_env:31:in `main'
	14: from /accounts-deployment/scripts/deployment.rb:158:in `create'
	13: from /usr/local/bundle/bundler/gems/aws-ruby-0546dfa266fa/lib/openstax/aws/stack.rb:61:in `create'
	12: from /usr/local/bundle/bundler/gems/aws-ruby-0546dfa266fa/lib/openstax/aws/secrets_set.rb:9:in `create'
	11: from /usr/local/bundle/bundler/gems/aws-ruby-0546dfa266fa/lib/openstax/aws/secrets_set.rb:9:in `each'
	10: from /usr/local/bundle/bundler/gems/aws-ruby-0546dfa266fa/lib/openstax/aws/secrets.rb:44:in `create'
	 9: from /usr/local/bundle/bundler/gems/aws-ruby-0546dfa266fa/lib/openstax/aws/secrets.rb:44:in `each'
	 8: from /usr/local/bundle/bundler/gems/aws-ruby-0546dfa266fa/lib/openstax/aws/secrets.rb:45:in `block in create'
	 7: from /usr/local/bundle/gems/aws-sdk-ssm-1.71.0/lib/aws-sdk-ssm/client.rb:6909:in `put_parameter'
	 6: from /usr/local/bundle/gems/aws-sdk-core-3.90.1/lib/seahorse/client/request.rb:70:in `send_request'
	 5: from /usr/local/bundle/gems/aws-sdk-core-3.90.1/lib/seahorse/client/plugins/response_target.rb:23:in `call'
	 4: from /usr/local/bundle/gems/aws-sdk-core-3.90.1/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call'
	 3: from /usr/local/bundle/gems/aws-sdk-core-3.90.1/lib/aws-sdk-core/plugins/param_converter.rb:24:in `call'
	 2: from /usr/local/bundle/gems/aws-sdk-core-3.90.1/lib/aws-sdk-core/plugins/idempotency_token.rb:17:in `call'
	 1: from /usr/local/bundle/gems/aws-sdk-core-3.90.1/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
/usr/local/bundle/gems/aws-sdk-core-3.90.1/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call': Rate exceeded (Aws::SSM::Errors::ThrottlingException)
```

To prevent this, I just added a tenth of a second per secret wait to over come this. 