### PR TITLE
Allow block form of `tag` on deployment classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,8 +740,16 @@ You can specify tags in all of a deployment's stacks by setting the tags at the 
 class MyDeployment < OpenStax::Aws::DeploymentBase
   tag :Application, "my_app"
   tag :Owner, "Jimmy"
+  tag(:Environment) { env_name }
   ...
+
+  def env_name
+    @env_name
+  end
 ```
+
+Note the block form of `tag` sets the tag value by evaluating the block in the context of the deployment instance,
+in this case by calling `env_name` on the deployment instance.
 
 Tags set at the stack level will override those set at the deployment level.
 

--- a/spec/deployment_base_spec.rb
+++ b/spec/deployment_base_spec.rb
@@ -228,6 +228,22 @@ RSpec.describe OpenStax::Aws::DeploymentBase do
 
       expect(instance.simple_stack.tags.map{|tag| {tag.key => tag.value}}).to contain_exactly({"howdy" => "there"}, {"foo" => "bar"})
     end
+
+    it "can set tags with blocks evaluated in the context of the deployment instance" do
+      deployment_class = Class.new(described_class) do
+        template_directory __dir__, 'support/templates'
+
+        tag(:foo) { bar }
+
+        def bar
+          "bar"
+        end
+      end
+
+      instance = deployment_class.new(name: "spec", region: "deployment-region")
+
+      expect(instance.tags).to eq({"foo" => "bar"})
+    end
   end
 
   context "deployment parameter defaults" do


### PR DESCRIPTION
See README.

Prior versions of the tag implementation may have had a bug, so probably good to use this version.