### PR TITLE
Extend timeout for distribution updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,9 @@ OpenStax::Aws.configure do |config|
   # The number of seconds the gem waits between polling for the completion of stack creation,
   # updates, deletes. (default: 30)
   config.stack_waiter_delay = 30
+  # The number of maximum attempts the gem makes to check for the completion of stack creation,
+  # updates, deletes. (default: 180)
+  config.stack_waiter_max_attempts = 180
   # If true, the gem will parse your template and autoset the required capabilities
   # (default: true)
   config.infer_stack_capabilities = true

--- a/lib/openstax/aws/stack.rb
+++ b/lib/openstax/aws/stack.rb
@@ -376,7 +376,8 @@ module OpenStax::Aws
         waiter_class.new(
           client: client,
           before_attempt: ->(*) { wait_message.say_it },
-          delay: OpenStax::Aws.configuration.stack_waiter_delay
+          delay: OpenStax::Aws.configuration.stack_waiter_delay,
+          max_attempts: OpenStax::Aws.configuration.stack_waiter_max_attempts
         ).wait(stack_name: name)
       rescue Aws::Waiters::Errors::WaiterFailed => error
         logger.error("Waiting failed: #{error.message}")

--- a/lib/openstax_aws.rb
+++ b/lib/openstax_aws.rb
@@ -47,6 +47,7 @@ module OpenStax
       attr_accessor :cfn_template_bucket_folder
       attr_writer :logger
       attr_accessor :stack_waiter_delay
+      attr_accessor :stack_waiter_max_attempts
       attr_accessor :infer_stack_capabilities
       attr_accessor :infer_parameter_defaults
       attr_accessor :production_env_name
@@ -56,6 +57,7 @@ module OpenStax
 
       def initialize
         @stack_waiter_delay = 30
+        @stack_waiter_max_attempts = 180
         @cfn_template_bucket_folder = "cfn_templates"
         @infer_stack_capabilities = true
         @infer_parameter_defaults = true

--- a/spec/stack_spec.rb
+++ b/spec/stack_spec.rb
@@ -100,9 +100,15 @@ RSpec.describe OpenStax::Aws::Stack, vcr: VCR_OPTS do
     name = "spec-aws-ruby-stack-update-new-parameters"
     tag_1 = "howdy"
     tag_2 = "there"
+    max_attempts = OpenStax::Aws.configuration.stack_waiter_max_attempts
 
     stack = new_template_one_stack(name: name)
     stack.create(params: {bucket_name: bucket_name, tag_value: "howdy"}, wait: true)
+
+    expect(max_attempts).to be_an(Integer)
+    expect(Aws::CloudFormation::Waiters::StackUpdateComplete).to receive(:new).with(hash_including(
+      :max_attempts => max_attempts
+    )).and_call_original
 
     stack.apply_change_set(params: {bucket_name: :use_previous_value, tag_value: "there"}, wait: true)
 


### PR DESCRIPTION
I've decided to increase the default amount of attempts (from 120) because i felt like increasing the polling time is not the way to go.
I'm not exactly sure how to test if it works. I've based it on the documentation.

for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/942