### PR TITLE
Add a DeploymentBase#stacks method for accessing a list of stacks

### DIFF
--- a/lib/openstax/aws/deployment_base.rb
+++ b/lib/openstax/aws/deployment_base.rb
@@ -81,6 +81,10 @@ module OpenStax::Aws
         end
       end
 
+      def stack_ids
+        @stack_ids ||= []
+      end
+
       def stack(id, &block)
         if id.blank?
           raise "The first argument to `stack` must be a non-blank ID"
@@ -94,6 +98,8 @@ module OpenStax::Aws
         if method_defined?("#{id}_secrets")
           raise "Cannot define `#{id}` stack because there are secrets with that ID"
         end
+
+        stack_ids.push(id)
 
         define_method("#{id}_stack") do
           instance_variable_get("@#{id}_stack") || begin
@@ -158,6 +164,10 @@ module OpenStax::Aws
       def tags
         @tags ||= HashWithIndifferentAccess.new
       end
+    end
+
+    def stacks
+      self.class.stack_ids.map{|id| self.send("#{id}_stack")}
     end
 
     def built_in_parameter_default(parameter_name)

--- a/spec/deployment_base_spec.rb
+++ b/spec/deployment_base_spec.rb
@@ -100,6 +100,31 @@ RSpec.describe OpenStax::Aws::DeploymentBase do
 
   end
 
+  context "#stacks" do
+    it "makes the stacks available via an array" do
+      deployment_class = Class.new(described_class) do
+        template_directory __dir__, 'support/templates/factory_test'
+
+        stack :network
+        stack :app
+      end
+
+      instance = deployment_class.new(name: "spec", env_name: "dev", region: "deployment-region", dry_run: false)
+
+      expect(instance.stacks.map(&:name)).to contain_exactly("dev-spec-network", "dev-spec-app")
+    end
+
+    it "works if no stacks defined" do
+      deployment_class = Class.new(described_class) do
+        template_directory __dir__, 'support/templates/factory_test'
+      end
+
+      instance = deployment_class.new(name: "spec", env_name: "dev", region: "deployment-region", dry_run: false)
+
+      expect(instance.stacks).to be_empty
+    end
+  end
+
   context "#stack" do
 
     it "sets a lot of default stack options" do


### PR DESCRIPTION
Add a DeploymentBase#stacks method for accessing a list of stacks in the deployment object instead of having to access them by their individual names.