### PR TITLE
allow tags definitions in parent deployment classes

### DIFF
--- a/lib/openstax/aws/deployment_base.rb
+++ b/lib/openstax/aws/deployment_base.rb
@@ -170,6 +170,13 @@ module OpenStax::Aws
       def tags
         @tags ||= HashWithIndifferentAccess.new
       end
+
+      def inherited(child_class)
+        # Copy any tags defined in the parent to the child so that it can access them
+        # while not using class variables that are shared across all classes in the
+        # that inherit here
+        child_class.instance_variable_set("@tags", tags.dup)
+      end
     end
 
     def stacks


### PR DESCRIPTION
Previously if you defined a tag in a parent deployment class, it didn't percolate down to the child class, e.g. this didn't work:

```ruby
class ParentDeployment < OpenStax::Aws::DeploymentBase
  tag :foo, "bar"
end

class ChildDeployment < ParentDeployment
  # didn't know about the `:foo` tag
end
```

The `DeploymentBase` class uses a class **instance** variable to store the tags.  Class instance variables are not shared through inheritance, which is why `:foo` is not a tag known to `ChildDeployment` above.  We could try to make the tags available to child classes by changing the variable it to a class variable, but then tags would be shared across different child classes, which is not good.

Instead, we kept using a class **instance** variable and added a hook to copy that parent's class instance variable to the child class when that child is defined.  