### PR TITLE
Disallow comma, semicolon in tag value

### DIFF
--- a/lib/openstax/aws/tag.rb
+++ b/lib/openstax/aws/tag.rb
@@ -4,7 +4,7 @@ module OpenStax::Aws
     attr_reader :key, :value
 
     AWS_TAG_KEY_REGEX =   /\A[\w\-\/.+=:@]{1,128}\z/
-    AWS_TAG_VALUE_REGEX = /\A[\w\-\/.+=:@;, ]{0,256}\z/
+    AWS_TAG_VALUE_REGEX = /\A[\w\-\/.+=:@ ]{0,256}\z/
 
     def initialize(key, value)
       if key.nil? || !key.match(AWS_TAG_KEY_REGEX)

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -33,7 +33,11 @@ RSpec.describe OpenStax::Aws::Tag do
     expect{described_class.new("foo", "a b")}.not_to raise_error
   end
 
-  it "allows values with commas" do
-    expect{described_class.new("foo", "a,b")}.not_to raise_error
+  it "rejects values with commas" do
+    expect{described_class.new("foo", "a,b")}.to raise_error(/matching/)
+  end
+
+  it "rejects values with semicolons" do
+    expect{described_class.new("foo", "a;b")}.to raise_error(/matching/)
   end
 end


### PR DESCRIPTION
IAM only accepts tag values that match the pattern `[\p{L}\p{Z}\p{N}_.:/=+\-@]*`, and so will reject anything with a comma or semicolon.