### PR TITLE
Fix Packer debugging by using getc instead of gets and unbuffered mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Fix Packer debug mode by reading and printing each character from Packer instead of each line.
+## [1.1.0] - 2020-10-20
 
-Restrict AMI search to images owned by the same account to prevent a potential security flaw.
+Fixed Packer debug mode by reading and printing each character from Packer instead of each line.
+
+Restricted AMI search to images owned by the same account to prevent a potential security flaw.
 
 ## [1.0.0] - 2020-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Fix Packer debug mode by reading and printing each character from Packer instead of each line.
+
+Restrict AMI search to images owned by the same account to prevent a potential security flaw.
+
 ## [1.0.0] - 2020-10-03
 
 First official version.

--- a/README.md
+++ b/README.md
@@ -922,6 +922,21 @@ your changes.
 
 Don't forget to delete your stack (from the console) when you are finished!
 
+## Gem Release Process
+
+When making a PR with a new feature or bug fix, add a changelog describing the change in
+CHANGELOG.md, under the Unreleased section.
+
+When releasing a new version, update lib/openstax/aws/version.rb, following semantic versioning.
+Then rename the Unreleased section on the changelog to the same version,
+adding the current date next to it.
+Finally, create a new Unreleased section at the top of the changelog.
+These steps can either be performed in a separate PR or in the same PR,
+if a new version is due for immediate release.
+
+After the PR is merged, pull the master branch, run tests to confirm that everything looks OK,
+then run `rake release` to push aws-ruby to rubygems.
+
 ## README Todos
 
 1. Discuss use of multiple secrets objects

--- a/lib/openstax/aws/packer_1_2_5.rb
+++ b/lib/openstax/aws/packer_1_2_5.rb
@@ -52,8 +52,10 @@ module OpenStax::Aws
         @logger.info("Printing stderr for desired verbosity")
 
         Open3.popen2e(command) do |stdin, stdout_err, wait_thr|
-          while line=stdout_err.gets do
-            puts(line)
+          stdout_err.sync = true
+
+          while char = stdout_err.getc do
+            print char
           end
         end
       end

--- a/lib/openstax/aws/packer_1_4_1.rb
+++ b/lib/openstax/aws/packer_1_4_1.rb
@@ -53,10 +53,20 @@ module OpenStax::Aws
         ami = ""
 
         Open3.popen2e(command) do |stdin, stdout_err, wait_thr|
-          while line=stdout_err.gets do
-            STDERR.puts(line)
+          stdout_err.sync = true
+
+          line = ''
+
+          while char = stdout_err.getc do
+            line << char
+            print char
+
+            next unless char == "\n"
+
             matchami = line.match(/AMI: (ami-[0-9\-a-z]*)/i)
             ami = matchami.captures[0] if matchami
+
+            line = ''
           end
         end
 

--- a/lib/openstax/aws/version.rb
+++ b/lib/openstax/aws/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Aws
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
Packer's debug mode prints lines that do not end on a newline and then waits for the user to press Enter.
Since aws-ruby was waiting for a whole line to print, these lines were not printing and Packer would sit there waiting for Enter with no indication to the user.