### PR TITLE
Set max_attempts for invalidation to 60 - increase from default 30

### DIFF
--- a/lib/openstax/aws/distribution.rb
+++ b/lib/openstax/aws/distribution.rb
@@ -34,7 +34,8 @@ module OpenStax::Aws
       begin
         Aws::CloudFront::Waiters::InvalidationCompleted.new(
           client: client,
-          before_attempt: ->(*) { wait_message.say_it }
+          before_attempt: ->(*) { wait_message.say_it },
+          max_attempts: 60
         ).wait(
           distribution_id: id,
           id: invalidation_id


### PR DESCRIPTION
for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/1537

https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/CloudFront/Waiters/InvalidationCompleted.html