### PR TITLE
Read the AMI ID from packer's manifest instead of the human-readable output

### DIFF
--- a/lib/openstax/aws/git_helper.rb
+++ b/lib/openstax/aws/git_helper.rb
@@ -11,7 +11,7 @@ module OpenStax::Aws
     def self.file_content_at_sha(org_slash_repo:, sha:, path:, github_token: nil )
       if github_token.blank?
         location = "https://raw.githubusercontent.com/#{org_slash_repo}/#{sha}/#{path}"
-        file = open(location)
+        file = URI.open(location)
         file.read
       else
         uri = URI("https://raw.githubusercontent.com/#{org_slash_repo}/#{sha}/#{path}")


### PR DESCRIPTION
If packer's manifest post-processor is not configured, then configure it
Should fix whatever problem is preventing the AMI ID output from working currently