### PR TITLE
AMIs tagged with deployment script SHA

### DIFF
--- a/lib/openstax/aws/build_image_command_1.rb
+++ b/lib/openstax/aws/build_image_command_1.rb
@@ -7,6 +7,7 @@ module OpenStax
       def initialize(ami_name_base:, region:,
                      verbose: false, debug: false,
                      github_org:, repo:, branch: nil, sha: nil,
+                     deployment_sha: nil,
                      packer_absolute_file_path: , playbook_absolute_file_path:,
                      dry_run: true)
         if sha.nil?
@@ -17,6 +18,8 @@ module OpenStax
                   branch: branch
                 )
         end
+
+        deployment_sha ||= OpenStax::Aws::GitHelper.current_sha
 
         ami_name = "#{ami_name_base}@#{sha[0..6]} #{Time.now.utc.strftime("%y%m%d%H%MZ")}"
 
@@ -30,9 +33,11 @@ module OpenStax
         @packer.var("region", region)
         @packer.var("ami_name", ami_name)
         @packer.var("sha", sha)
+        @packer.var("deployment_sha", deployment_sha)
         @packer.var("playbook_file", playbook_absolute_file_path)
         @packer.var("ami_description", {
           sha: sha,
+          deployment_sha: deployment_sha,
           github_org: github_org,
           repo: repo
         }.to_json)

--- a/lib/openstax/aws/git_helper.rb
+++ b/lib/openstax/aws/git_helper.rb
@@ -3,7 +3,6 @@ require 'open-uri'
 
 module OpenStax::Aws
   module GitHelper
-
     def self.sha_for_branch_name(org_slash_repo:, branch:)
       ::Git.ls_remote("https://github.com/#{org_slash_repo}")["branches"][branch][:sha]
     end
@@ -22,6 +21,10 @@ module OpenStax::Aws
            response.body
         end
       end
+    end
+
+    def self.current_sha
+      ::Git.revparse('HEAD')
     end
   end
 end

--- a/lib/openstax/aws/image.rb
+++ b/lib/openstax/aws/image.rb
@@ -25,9 +25,12 @@ module OpenStax::Aws
       get_tag(key: "sha")
     end
 
-    def self.find_by_sha(sha:, region:)
+    def self.find_by_sha(sha:, region:, deployment_sha: nil)
+      filters = [{name: "tag:sha", values: [sha]}]
+      filters << {name: "tag:deployment_sha", values: [deployment_sha]} unless deployment_sha.nil?
+
       Aws::EC2::Client.new(region: region).describe_images({
-        owners: ['self'], filters: [{name: "tag:sha", values: [sha]}]
+        owners: ['self'], filters: filters
       }).images.map{|aws_image| new(aws_image: aws_image)}
     end
   end


### PR DESCRIPTION
- Pass the deployment_sha to packer so the AMI can be tagged with it
- Allow AMI search to find AMIs with a specific deployment version
- Added a current_sha Git helper

Need this new deployment_sha tag to properly filter for AMIs that have been built using the correct deployment version