### PR TITLE
Fixed/renamed the current_sha helper

### DIFF
--- a/lib/openstax/aws/build_image_command_1.rb
+++ b/lib/openstax/aws/build_image_command_1.rb
@@ -19,8 +19,6 @@ module OpenStax
                 )
         end
 
-        deployment_sha ||= OpenStax::Aws::GitHelper.current_sha
-
         ami_name = "#{ami_name_base}@#{sha[0..6]} #{Time.now.utc.strftime("%y%m%d%H%MZ")}"
 
         @packer = OpenStax::Aws::PackerFactory.new_packer(
@@ -33,7 +31,7 @@ module OpenStax
         @packer.var("region", region)
         @packer.var("ami_name", ami_name)
         @packer.var("sha", sha)
-        @packer.var("deployment_sha", deployment_sha)
+        @packer.var("deployment_sha", deployment_sha) unless deployment_sha.nil?
         @packer.var("playbook_file", playbook_absolute_file_path)
         @packer.var("ami_description", {
           sha: sha,

--- a/lib/openstax/aws/git_helper.rb
+++ b/lib/openstax/aws/git_helper.rb
@@ -22,5 +22,10 @@ module OpenStax::Aws
         end
       end
     end
+
+    def self.local_repo_sha(path: nil)
+      path ||= Dir.pwd
+      ::Git.open(path).revparse('HEAD')
+    end
   end
 end

--- a/lib/openstax/aws/git_helper.rb
+++ b/lib/openstax/aws/git_helper.rb
@@ -22,10 +22,5 @@ module OpenStax::Aws
         end
       end
     end
-
-    def self.current_sha
-      # Git.open('.').revparse('HEAD') does not work on sub-folders, unlike `git rev-parse HEAD`
-      `git rev-parse HEAD`.chomp
-    end
   end
 end

--- a/lib/openstax/aws/git_helper.rb
+++ b/lib/openstax/aws/git_helper.rb
@@ -24,7 +24,8 @@ module OpenStax::Aws
     end
 
     def self.current_sha
-      ::Git.revparse('HEAD')
+      # Git.open('.').revparse('HEAD') does not work on sub-folders, unlike `git rev-parse HEAD`
+      `git rev-parse HEAD`.chomp
     end
   end
 end

--- a/lib/openstax/aws/version.rb
+++ b/lib/openstax/aws/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Aws
-    VERSION = "1.6.0"
+    VERSION = "1.6.1"
   end
 end


### PR DESCRIPTION
We'll just make BuildImageCommand1 not set the packer var if the parameter is not passed in