### PR TITLE
Defaul image build command branch to main

### DIFF
--- a/lib/openstax/aws/build_image_command_1.rb
+++ b/lib/openstax/aws/build_image_command_1.rb
@@ -11,7 +11,7 @@ module OpenStax
                      packer_absolute_file_path: , playbook_absolute_file_path:,
                      dry_run: true)
         if sha.nil?
-          branch ||= 'master'
+          branch ||= 'main'
 
           sha = OpenStax::Aws::GitHelper.sha_for_branch_name(
                   org_slash_repo: "#{github_org}/#{repo}",

--- a/lib/openstax/aws/version.rb
+++ b/lib/openstax/aws/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Aws
-    VERSION = "2.0.1"
+    VERSION = "2.1.0"
   end
 end


### PR DESCRIPTION
I wasted a bunch of time debugging this today. Pretty sure we can just default to main now, or fix anything that breaks.